### PR TITLE
Downgraded makefile workflow to run on gcc version 10.5

### DIFF
--- a/.github/workflows/check_makefile.yml
+++ b/.github/workflows/check_makefile.yml
@@ -13,7 +13,15 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y make gcc libreadline-dev
+        sudo apt-get install -y software-properties-common
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+        sudo apt-get update
+        sudo apt-get install -y gcc-10 g++-10 libreadline-dev
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 10
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 10
+
+    - name: Verify GCC version
+      run: gcc --version
 
     - name: Run Makefile
       run: make all


### PR DESCRIPTION
Downgraded the gcc version the Makefile workflow, now it runs on the same version as the school computers.