### PR TITLE
FIXED: added missing exit point in execute_cmd() in case of access() …

### DIFF
--- a/src/execution/process_command.c
+++ b/src/execution/process_command.c
@@ -6,7 +6,7 @@
 /*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/10 13:07:11 by jteissie          #+#    #+#             */
-/*   Updated: 2024/07/15 15:05:10 by jteissie         ###   ########.fr       */
+/*   Updated: 2024/07/16 11:29:47 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,8 @@ void	execute_cmd(char *cmd, char **env, t_parser	*data)
 			handle_error(strerror(errno), errno);
 		}
 	}
+	trash(command);
+	handle_error(strerror(errno), errno);
 }
 
 void	check_pipes(t_lex_parser *table, int pipe_status[])


### PR DESCRIPTION
Fixed child not exiting properly after access() would return an error.

This is what caused the program to sometimes need several ctrl+D to exit the prompt, as the user would need to exit every child manually.