### PR TITLE
Adds build_env() function to rebuild the env array whenever needed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ CFILES	= main.c \
 		  build_redirect_table.c \
 		  execute_commands.c \
 		  execution_utils.c \
+		  build_env.c \
 		  process_command.c \
 		  redir_child.c \
 		  parse_here_doc.c \

--- a/include/execution.h
+++ b/include/execution.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execution.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
+/*   By: marvin <marvin@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/07 16:53:36 by jteissie          #+#    #+#             */
-/*   Updated: 2024/07/17 19:55:35 by bthomas          ###   ########.fr       */
+/*   Updated: 2024/07/17 22:36:51 by marvin           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,9 +24,12 @@
 # define CHILD 0
 # define PARENT 1
 
+typedef struct s_varlist		t_varlist;
+
 void	trash(char **array);
 void	handle_error(char *message, int code);
-void	execute_cmd(char *cmd, char **env, t_parser *data);
+void	execute_cmd(char *cmd, t_data *data, t_parser *parser);
+char	**build_env(t_varlist *vars);
 
 int		process_files(t_lex_parser *table);
 int		get_redirections(t_lex_parser *roaming, char *redirection[]);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
+/*   By: marvin <marvin@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 13:21:34 by bthomas           #+#    #+#             */
-/*   Updated: 2024/07/17 20:31:34 by bthomas          ###   ########.fr       */
+/*   Updated: 2024/07/17 22:32:37 by marvin           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,7 @@
 
 typedef struct s_heredoc_data	t_heredoc_data;
 typedef struct s_data			t_data;
+typedef struct s_varlist		t_varlist;
 
 typedef struct s_heredoc
 {
@@ -55,8 +56,6 @@ typedef struct s_heredoc_data
 	t_heredoc		*heredoc;
 	t_heredoc_data	*next;
 }	t_heredoc_data;
-
-typedef struct s_varlist		t_varlist;
 
 typedef struct s_varlist
 {

--- a/src/cleanup.c
+++ b/src/cleanup.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cleanup.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
+/*   By: marvin <marvin@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/07 12:30:45 by bthomas           #+#    #+#             */
-/*   Updated: 2024/07/16 14:57:12 by bthomas          ###   ########.fr       */
+/*   Updated: 2024/07/17 23:29:14 by marvin           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,5 +82,15 @@ int	clean_exit(t_data *data, int exit_code)
 	free_lexmem(data);
 	rl_clear_history();
 	free_env(data);
+	if (data->parsedata)
+	{
+		free_parsed_mem(data->parsedata);
+		free(data->parsedata);
+	}
+	if (data->heredata)
+	{
+		unlink_heredocs(data);
+		free(data->heredata);
+	}
 	return (exit_code);
 }

--- a/src/execution/build_env.c
+++ b/src/execution/build_env.c
@@ -1,0 +1,78 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   build_env.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: marvin <marvin@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/07/17 22:25:06 by marvin            #+#    #+#             */
+/*   Updated: 2024/07/17 22:25:06 by marvin           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static	int	count_vars(t_varlist *vars)
+{
+	int			count;
+	t_varlist	*roaming;
+
+	count = 0;
+	roaming = vars;
+	while (roaming)
+	{
+		count++;
+		roaming = roaming->next;
+	}
+	return (count);
+}
+
+static void	panic_free(char **env)
+{
+	int	i;
+
+	if (!env)
+		return ;
+	i = 0;
+	while (env[i])
+	{
+		free(env[i]);
+		i++;
+	}
+	env = NULL;
+}
+
+static void	assemble_strings(char *env, t_varlist *roaming)
+{
+	env = ft_strdup(roaming->key);
+	env = ft_str_rejoin(env, "=");
+	env = ft_str_rejoin(env, roaming->val);
+}
+
+char	**build_env(t_varlist *vars)
+{
+	char		**env;
+	int			vars_count;
+	int			i;
+	t_varlist	*roaming;
+
+	vars_count = count_vars(vars);
+	roaming = vars;
+	i = 0;
+	env = ft_calloc(vars_count + 1, sizeof(char *));
+	if (!env)
+		return (NULL);
+	while (roaming)
+	{
+		assemble_strings(env[i], roaming);
+		if (!env[i])
+		{
+			panic_free(env);
+			break ;
+		}
+		roaming = roaming->next;
+		i++;
+	}
+	env[i] = NULL;
+	return (env);
+}

--- a/src/execution/process_command.c
+++ b/src/execution/process_command.c
@@ -3,36 +3,33 @@
 /*                                                        :::      ::::::::   */
 /*   process_command.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
+/*   By: marvin <marvin@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/10 13:07:11 by jteissie          #+#    #+#             */
-/*   Updated: 2024/07/17 19:55:59 by bthomas          ###   ########.fr       */
+/*   Updated: 2024/07/17 22:37:08 by marvin           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-void	execute_cmd(char *cmd, char **env, t_parser	*data)
+void	execute_cmd(char *cmd, t_data *data, t_parser	*parser)
 {
 	char	**command;
+	char	**env;
 
 	command = ft_split(cmd, ' ');
-	free_parsed_mem(data);
+	free_parsed_mem(parser);
 	if (!command || !command[0])
 	{
 		if (command)
 			trash(command);
 		handle_error("Command split error", EXIT_FAILURE);
 	}
+	env = build_env(data->env_vars);
 	if (access(command[0], F_OK | X_OK) == 0)
-	{
-		if (execve(command[0], command, env) == -1)
-		{
-			trash(command);
-			handle_error(strerror(errno), errno);
-		}
-	}
+		execve(command[0], command, env);
 	trash(command);
+	trash(env);
 	handle_error(strerror(errno), errno);
 }
 
@@ -69,7 +66,7 @@ void	execute_child(char *cmd, t_data *data)
 	if (is_builtin(cmd, 0))
 		execute_builtin(cmd, data, CHILD);
 	else
-		execute_cmd(cmd, data->env, data->parsedata);
+		execute_cmd(cmd, data, data->parsedata);
 	exit(EXIT_SUCCESS);
 }
 

--- a/src/here_doc_parsing/here_doc_utils.c
+++ b/src/here_doc_parsing/here_doc_utils.c
@@ -57,14 +57,12 @@ void	unlink_heredocs(t_data *data)
 {
 	t_heredoc_data	*roaming;
 	t_heredoc_data	*temp;
-	int				index;
 	t_heredoc_data	*here_data;
 
 	here_data = data->heredata;
 	if (!here_data->heredoc)
 		return ;
 	roaming = here_data;
-	index = 0;
 	while (roaming)
 	{
 		temp = roaming;
@@ -73,9 +71,9 @@ void	unlink_heredocs(t_data *data)
 				ft_printf("Error deleting file '%s': %s\n",
 					temp->heredoc->path, strerror(errno));
 		free(temp->heredoc);
-		if (index > 0)
-			free(temp);
+		free(temp);
 		roaming = roaming->next;
 	}
 	here_data->heredoc = NULL;
+	data->heredata = NULL;
 }

--- a/src/parser/parser_clean_exit.c
+++ b/src/parser/parser_clean_exit.c
@@ -6,7 +6,7 @@
 /*   By: marvin <marvin@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/13 19:21:20 by jteissie          #+#    #+#             */
-/*   Updated: 2024/07/15 21:24:51 by marvin           ###   ########.fr       */
+/*   Updated: 2024/07/17 23:27:59 by marvin           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,4 +58,5 @@ void	free_parsed_mem(t_parser *data)
 		free(temp);
 	}
 	data->node = NULL;
+	data = NULL;
 }


### PR DESCRIPTION
Added build_env function to rebuild the environment array from the linked list in data->var_list.Added build_env() call to execute_cmd() to pass the up to date environment array to execve().

Added missing logic to clean_exit() to catch any used memory blocks allocated by init().

This patches an oversight with the current implementation of the env_vars linked list.