### PR TITLE
Fixes exit printing to the terminal when executed within a subshell

### DIFF
--- a/include/built_ins.h
+++ b/include/built_ins.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   built_ins.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
+/*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/16 17:58:36 by jteissie          #+#    #+#             */
-/*   Updated: 2024/07/19 17:49:31 by bthomas          ###   ########.fr       */
+/*   Updated: 2024/07/22 13:56:42 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@ void	execute_builtin(char *cmd, t_data *data, int mode);
 
 void	call_echo(t_data *data, char **cmd);
 void	call_cd(t_data *data, char **cmd);
-void	call_exit(t_data *data, char **cmd);
+void	call_exit(t_data *data, char **cmd, int mode);
 void	call_pwd(void);
 void	call_export(t_data *data, char **cmd);
 void	call_env(t_data *data);

--- a/src/built_ins/built_ins.c
+++ b/src/built_ins/built_ins.c
@@ -6,7 +6,7 @@
 /*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/16 17:59:53 by jteissie          #+#    #+#             */
-/*   Updated: 2024/07/21 18:39:46 by jteissie         ###   ########.fr       */
+/*   Updated: 2024/07/22 13:56:49 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ void	call_builtin(char **command, t_data *data, int mode)
 			close(FD_STDIN);
 			close(FD_STDOUT);
 		}
-		call_exit(data, command);
+		call_exit(data, command, mode);
 	}
 	else if (ft_strcmp(command[0], "export") == 0)
 		call_export(data, command);

--- a/src/built_ins/exit.c
+++ b/src/built_ins/exit.c
@@ -6,7 +6,7 @@
 /*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/16 19:27:00 by jteissie          #+#    #+#             */
-/*   Updated: 2024/07/21 18:39:46 by jteissie         ###   ########.fr       */
+/*   Updated: 2024/07/22 14:03:52 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,31 +36,36 @@ void	exit_error(char **cmd)
 	free_strarray(cmd);
 }
 
-void	call_exit(t_data *data, char **cmd)
+static int	check_overflow(char *str)
+{
+	if (ft_strlen(str) > 11)
+		return (TRUE);
+	return (FALSE);
+}
+
+void	call_exit(t_data *data, char **cmd, int mode)
 {
 	int	exit_code;
 
 	(void)data;
 	exit_code = EXIT_FAILURE;
-	if (!cmd[1])
+	if (!cmd[1] || cmd[2])
 	{
 		free_strarray(cmd);
-		ft_putstr_fd("exit\n", STDOUT_FILENO);
+		if (mode == PARENT && !cmd[1])
+			ft_putstr_fd("exit\n", STDOUT_FILENO);
+		else if (cmd[1] && cmd[2])
+			ft_putstr_fd("minishell: exit: too may arguments\n", STDERR_FILENO);
 		exit(clean_exit(data, EXIT_FAILURE));
 	}
-	if (cmd[2] != NULL)
-	{
-		free_strarray(cmd);
-		ft_putstr_fd("minishell: exit: too may arguments\n", STDERR_FILENO);
-		exit(clean_exit(data, EXIT_FAILURE));
-	}
-	if (is_not_number(cmd[1]) == TRUE)
+	if (is_not_number(cmd[1]) == TRUE || check_overflow(cmd[1]))
 	{
 		exit_error(cmd);
 		exit(clean_exit(data, EXIT_FAILURE));
 	}
 	exit_code = ft_atoi(cmd[1]);
-	ft_putstr_fd("exit\n", STDOUT_FILENO);
+	if (mode == PARENT)
+		ft_putstr_fd("exit\n", STDOUT_FILENO);
 	free_strarray(cmd);
 	exit(clean_exit(data, exit_code));
 }

--- a/src/built_ins/exit.c
+++ b/src/built_ins/exit.c
@@ -6,13 +6,13 @@
 /*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/16 19:27:00 by jteissie          #+#    #+#             */
-/*   Updated: 2024/07/22 14:03:52 by jteissie         ###   ########.fr       */
+/*   Updated: 2024/07/22 14:18:44 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	is_not_number(char *str)
+static int	is_not_number(char *str)
 {
 	int	index;
 
@@ -28,7 +28,7 @@ int	is_not_number(char *str)
 	return (FALSE);
 }
 
-void	exit_error(char **cmd)
+static void	exit_error(char **cmd)
 {
 	ft_putstr_fd("minishell: exit: ", STDERR_FILENO);
 	ft_putstr_fd(cmd[1], STDERR_FILENO);
@@ -36,16 +36,9 @@ void	exit_error(char **cmd)
 	free_strarray(cmd);
 }
 
-static int	check_overflow(char *str)
-{
-	if (ft_strlen(str) > 11)
-		return (TRUE);
-	return (FALSE);
-}
-
 void	call_exit(t_data *data, char **cmd, int mode)
 {
-	int	exit_code;
+	long	exit_code;
 
 	(void)data;
 	exit_code = EXIT_FAILURE;
@@ -58,7 +51,7 @@ void	call_exit(t_data *data, char **cmd, int mode)
 			ft_putstr_fd("minishell: exit: too may arguments\n", STDERR_FILENO);
 		exit(clean_exit(data, EXIT_FAILURE));
 	}
-	if (is_not_number(cmd[1]) == TRUE || check_overflow(cmd[1]))
+	if (is_not_number(cmd[1]) == TRUE)
 	{
 		exit_error(cmd);
 		exit(clean_exit(data, EXIT_FAILURE));


### PR DESCRIPTION
Added check against mode in call_exit() to decide whether or not to print the exit message.

Removed unecessary overflow check logic, it is UB in Bash posix.