### PR TITLE
Fixes errcode not properly updating, adds printing of bad command when access returns exception

### DIFF
--- a/include/execution.h
+++ b/include/execution.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execution.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
+/*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/07 16:53:36 by jteissie          #+#    #+#             */
-/*   Updated: 2024/07/22 12:12:02 by bthomas          ###   ########.fr       */
+/*   Updated: 2024/07/22 14:28:53 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,7 @@ typedef struct s_pid_data
 	t_pid_data	*next;
 }	t_pid_data;
 
-void	handle_error(char *message, int code, t_data *data);
+void	handle_error(char *message, int code, t_data *data, char **cmd);
 void	execute_cmd(char *cmd, t_data *data);
 char	**build_env(t_varlist *vars);
 int		count_commands(t_parser *data);

--- a/src/built_ins/built_ins.c
+++ b/src/built_ins/built_ins.c
@@ -6,7 +6,7 @@
 /*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/16 17:59:53 by jteissie          #+#    #+#             */
-/*   Updated: 2024/07/21 18:39:46 by jteissie         ###   ########.fr       */
+/*   Updated: 2024/07/22 14:29:05 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,7 +53,7 @@ void	execute_builtin(char *cmd, t_data *data, int mode)
 		if (command)
 			free_strarray(command);
 		if (mode == CHILD)
-			handle_error("Built_in split error", EXIT_FAILURE, data);
+			handle_error("Built_in split error", EXIT_FAILURE, data, NULL);
 		else
 			return ;
 	}

--- a/src/execution/execution_utils.c
+++ b/src/execution/execution_utils.c
@@ -6,7 +6,7 @@
 /*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/07 18:14:25 by jteissie          #+#    #+#             */
-/*   Updated: 2024/07/22 14:28:44 by jteissie         ###   ########.fr       */
+/*   Updated: 2024/07/22 14:43:52 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ void	handle_error(char *message, int code, t_data *data, char **cmd)
 	if (code == CANNOT_EXECUTE)
 		message = ": cannot execute command";
 	ft_putstr_fd("minishell: ", STDERR_FILENO);
-	if(cmd && cmd[0])
+	if (cmd && cmd[0])
 		ft_putstr_fd(cmd[0], STDERR_FILENO);
 	ft_putstr_fd(message, STDERR_FILENO);
 	ft_putchar_fd('\n', STDERR_FILENO);

--- a/src/execution/execution_utils.c
+++ b/src/execution/execution_utils.c
@@ -3,23 +3,28 @@
 /*                                                        :::      ::::::::   */
 /*   execution_utils.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
+/*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/07 18:14:25 by jteissie          #+#    #+#             */
-/*   Updated: 2024/07/22 12:11:51 by bthomas          ###   ########.fr       */
+/*   Updated: 2024/07/22 14:28:44 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-void	handle_error(char *message, int code, t_data *data)
+void	handle_error(char *message, int code, t_data *data, char **cmd)
 {
 	if (code == NOT_FOUND)
-		message = "minishell: command not found";
+		message = ": command not found";
 	if (code == CANNOT_EXECUTE)
-		message = "minishell: cannot execute command";
+		message = ": cannot execute command";
+	ft_putstr_fd("minishell: ", STDERR_FILENO);
+	if(cmd && cmd[0])
+		ft_putstr_fd(cmd[0], STDERR_FILENO);
 	ft_putstr_fd(message, STDERR_FILENO);
 	ft_putchar_fd('\n', STDERR_FILENO);
+	if (cmd)
+		free_strarray(cmd);
 	exit(clean_exit(data, code));
 }
 

--- a/src/execution/process_command.c
+++ b/src/execution/process_command.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   process_command.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: bthomas <bthomas@student.42.fr>            +#+  +:+       +#+        */
+/*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/10 13:07:11 by jteissie          #+#    #+#             */
-/*   Updated: 2024/07/22 12:11:40 by bthomas          ###   ########.fr       */
+/*   Updated: 2024/07/22 14:29:22 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ void	execute_cmd(char *cmd, t_data *data)
 	{
 		if (command)
 			free_strarray(command);
-		handle_error("127: command not found", PATH_ERROR, data);
+		handle_error("127: command not found", PATH_ERROR, data, NULL);
 	}
 	env = build_env(data->env_vars);
 	if (access(command[0], F_OK) != 0)
@@ -31,9 +31,8 @@ void	execute_cmd(char *cmd, t_data *data)
 		data->errcode = CANNOT_EXECUTE;
 	else
 		execve(command[0], command, env);
-	free_strarray(command);
 	free_strarray(env);
-	handle_error(strerror(errno), data->errcode, data);
+	handle_error(strerror(errno), data->errcode, data, command);
 }
 
 int	open_pipes(t_parser *parsed, int p_fd[], int has_pipe[])
@@ -85,7 +84,7 @@ int	process_command(t_parser *p, t_data *data, int std_fd[])
 	if (pid_child == 0)
 	{
 		if (redir_child(p, pipe_fd, has_pipe, std_fd) == PANIC)
-			handle_error(strerror(errno), errno, data);
+			handle_error(strerror(errno), errno, data, NULL);
 		execute_child(cmd_table->cmd, data);
 	}
 	else

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: jteissie <jteissie@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/25 13:43:42 by bthomas           #+#    #+#             */
-/*   Updated: 2024/07/21 18:37:13 by jteissie         ###   ########.fr       */
+/*   Updated: 2024/07/22 14:42:46 by jteissie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,14 +66,14 @@ int	main(int argc, char **argv, char **env)
 	while (1)
 	{
 		init_signals();
+		data.prompt = get_prompt(data.prompt);
+		if (get_input(&data, data.prompt) == PANIC)
+			break ;
 		if (g_sig_offset)
 		{
 			data.errcode = SIG_OFFSET + 2;
 			g_sig_offset = 0;
 		}
-		data.prompt = get_prompt(data.prompt);
-		if (get_input(&data, data.prompt) == PANIC)
-			break ;
 		if (tokenize_data(&data) == PANIC)
 			continue ;
 		parse_data(&data);


### PR DESCRIPTION
Refactored handle_error to print the command name when access() throws an exception. (closes https://github.com/Haliris/minishell/issues/78)
Moved sigofffset check in main() to check for sigints immediately after get_prompt() so that it gets updated properly before being passed to exec.